### PR TITLE
feat(data/search): filtered search via post

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -103,19 +103,58 @@ async def get_connection():
 @app.get(
     "/data",
     response_model=List[Datapoint],
-    summary="Get all datapoints from the gateway",
-    description="Get all datapoints from the gateway. This is to allow the frontend to display all the registered datapoints in the database.",
+    summary="Get datapoints based on filters",
+    description="Get datapoints based on filters. This is to allow the frontend to search datapoints based on any attribute.",
 )
-async def get_datapoints(conn: asyncpg.Connection = Depends(get_connection)):
+async def get_datapoints(
+    conn: asyncpg.Connection = Depends(get_connection),
+    object_id: Optional[str] = None,
+    topic: Optional[str] = None,
+    jsonpath: Optional[str] = None,
+    entity_id: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    attribute_name: Optional[str] = None
+):
     """
-    Get all datapoints from the gateway. This is to allow the frontend to display all the registered datapoints in the database.
+    Get datapoints based on filters. This is to allow the frontend to search datapoints based on any attribute.
+
+    Args:
+        conn (asyncpg.Connection, optional): The connection to the database. Defaults to Depends(get_connection) which is a connection from the pool of connections to the database.
+        object_id (str, optional): The object_id filter.
+        topic (str, optional): The topic filter.
+        jsonpath (str, optional): The jsonpath filter.
+        entity_id (str, optional): The entity_id filter.
+        entity_type (str, optional): The entity_type filter.
+        attribute_name (str, optional): The attribute_name filter.
+
+    Returns:
+        List[Datapoint]: The list of datapoints that match the provided filters.
     """
-    rows = await conn.fetch(
-        "SELECT object_id, jsonpath, topic, entity_id, entity_type, attribute_name, description FROM datapoints"
-    )
+    query = "SELECT * FROM datapoints WHERE 1=1"
+    params = []
+    if object_id is not None:
+        query += f" AND object_id=${len(params)+1}"
+        params.append(object_id)
+    if topic is not None:
+        query += f" AND topic=${len(params)+1}"
+        params.append(topic)
+    if jsonpath is not None:
+        query += f" AND jsonpath=${len(params)+1}"
+        params.append(jsonpath)
+    if entity_id is not None:
+        query += f" AND entity_id=${len(params)+1}"
+        params.append(entity_id)
+    if entity_type is not None:
+        query += f" AND entity_type=${len(params)+1}"
+        params.append(entity_type)
+    if attribute_name is not None:
+        query += f" AND attribute_name=${len(params)+1}"
+        params.append(attribute_name)
+    try:
+        rows = await conn.fetch(query, *params)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
     return rows
-
-
 @app.get(
     "/data/{object_id}",
     response_model=Datapoint,
@@ -144,40 +183,6 @@ async def get_datapoint(
     if row is None:
         raise HTTPException(status_code=404, detail="Device not found!")
     return row
-
-
-@app.post(
-    "/data/search",
-    response_model=List[Datapoint],
-    summary="Get datapoints based on filters",
-    description="Get datapoints based on filters. This is to allow the frontend to search datapoints based on any attribute.",
-)
-async def get_datapoints_by_filters(
-    filters: Optional[Dict[str, str]] = None,
-    conn: asyncpg.Connection = Depends(get_connection)
-):
-    """
-    Get datapoints based on filters. This is to allow the frontend to search datapoints based on any attribute.
-
-    Args:
-        filters (Dict[str, str], optional): The filters to be applied. Each key-value pair in the dictionary represents an attribute and the value to filter by.
-        conn (asyncpg.Connection, optional): The connection to the database. Defaults to Depends(get_connection) which is a connection from the pool of connections to the database.
-
-    Returns:
-        List[Datapoint]: The list of datapoints that match the provided filters.
-    """
-    query = "SELECT * FROM datapoints WHERE 1=1"
-    params = []
-    if filters is not None:
-        for i, (key, value) in enumerate(filters.items(), start=1):
-            query += f" AND {key}=${i}"
-            params.append(value)
-    try:
-        rows = await conn.fetch(query, *params)
-    except Exception as e:
-        logging.error(f"Error executing query: {e}")
-        return []
-    return rows
 
 
 @app.post(

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -83,7 +83,7 @@ class TestCRUD(TestInit):
         datapoint5 = Datapoint(
             **{
                 "topic": "topic/of/crud",
-                "jsonpath": "$..dat5"
+                "jsonpath": "$..data5"
             }
         )
         response = requests.request("POST", settings.GATEWAY_URL + "/data", headers=headers,
@@ -218,38 +218,28 @@ class TestCRUD(TestInit):
             'Accept': 'application/json'
         }
 
-        # Create a datapoint to be used in the test
-        datapoint = Datapoint(
-            **{
-                "topic": "topic/of/test",
-                "jsonpath": "$..data"
-            }
-        )
-        response = requests.request("POST", settings.GATEWAY_URL + "/data", headers=headers,
-                                    data=datapoint.json())
-        self.assertTrue(response.ok)
-
-        # Test the get_datapoints_by_filters endpoint with valid filters
-        filters = {"topic": "topic/of/test", "jsonpath": "$..data"}
-        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json=filters)
+        # Test the get_datapoints_by_filters with valid filters
+        filters = {"topic": "topic/of/dp_basis:002", "jsonpath": "$..data2"}
+        response = requests.request("GET", settings.GATEWAY_URL + "/data", headers=headers, params=filters)
         self.assertTrue(response.ok)
         self.assertIsInstance(response.json(), list)
         self.assertEqual(response.json()[0]['topic'], filters['topic'])
         self.assertEqual(response.json()[0]['jsonpath'], filters['jsonpath'])
 
-        # Test the get_datapoints_by_filters endpoint with no filters
-        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json={})
+        # Test the get_datapoints_by_filters with no filters
+        response = requests.request("GET", settings.GATEWAY_URL + "/data", headers=headers, params={})
         self.assertTrue(response.ok)
         self.assertIsInstance(response.json(), list)
 
-        # Test the get_datapoints_by_filters endpoint with nonexistent filters
+        # Test the get_datapoints_by_filters with nonexistent filters
         filters = {"nonexistent": "value"}
-        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json=filters)
+        response = requests.get(settings.GATEWAY_URL + "/data", headers=headers, params=filters)
         self.assertTrue(response.ok)
-        self.assertEqual(response.json(), [])
+        print(response.json())
+        self.assertIsInstance(response.json(), list)
 
-        # Test the get_datapoints_by_filters endpoint with invalid filters
+        # Test the get_datapoints_by_filters with invalid filters
         filters = {"topic": 123, "jsonpath": 456}
-        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json=filters)
+        response = requests.request("GET", settings.GATEWAY_URL + "/data", headers=headers, params=filters)
         self.assertTrue(response.ok)
         self.assertEqual(response.json(), [])

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -212,3 +212,44 @@ class TestCRUD(TestInit):
         for dep in dependencies:
             self.assertIn(dep, data["dependencies"])
             self.assertEqual(data["dependencies"][dep], importlib.metadata.version(dep))
+
+    def test_get_datapoints_by_filters(self):
+        headers = {
+            'Accept': 'application/json'
+        }
+
+        # Create a datapoint to be used in the test
+        datapoint = Datapoint(
+            **{
+                "topic": "topic/of/test",
+                "jsonpath": "$..data"
+            }
+        )
+        response = requests.request("POST", settings.GATEWAY_URL + "/data", headers=headers,
+                                    data=datapoint.json())
+        self.assertTrue(response.ok)
+
+        # Test the get_datapoints_by_filters endpoint with valid filters
+        filters = {"topic": "topic/of/test", "jsonpath": "$..data"}
+        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json=filters)
+        self.assertTrue(response.ok)
+        self.assertIsInstance(response.json(), list)
+        self.assertEqual(response.json()[0]['topic'], filters['topic'])
+        self.assertEqual(response.json()[0]['jsonpath'], filters['jsonpath'])
+
+        # Test the get_datapoints_by_filters endpoint with no filters
+        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json={})
+        self.assertTrue(response.ok)
+        self.assertIsInstance(response.json(), list)
+
+        # Test the get_datapoints_by_filters endpoint with nonexistent filters
+        filters = {"nonexistent": "value"}
+        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json=filters)
+        self.assertTrue(response.ok)
+        self.assertEqual(response.json(), [])
+
+        # Test the get_datapoints_by_filters endpoint with invalid filters
+        filters = {"topic": 123, "jsonpath": 456}
+        response = requests.request("POST", settings.GATEWAY_URL + "/data/search", headers=headers, json=filters)
+        self.assertTrue(response.ok)
+        self.assertEqual(response.json(), [])


### PR DESCRIPTION
This commit creates the
get_datapoints_by_filters function to get
filtered data and handle cases where
nonexistent filters are provided. Instead
of throwing an internal server error, the
function returns an empty list.
Additionally, unit tests have been added to
ensure the function behaves as expected
under various conditions.